### PR TITLE
Adds Trilogy adapter support

### DIFF
--- a/lib/activerecord/health.rb
+++ b/lib/activerecord/health.rb
@@ -93,7 +93,7 @@ module ActiveRecord
       def adapter_class_for(connection)
         case connection.adapter_name.downcase
         when /postgresql/ then Adapters::PostgreSQLAdapter
-        when /mysql/ then Adapters::MySQLAdapter
+        when /mysql/, /trilogy/ then Adapters::MySQLAdapter
         else raise "Unsupported database adapter: #{connection.adapter_name}"
         end
       end


### PR DESCRIPTION
I was checking out the gem but immediately hit:

```
#<RuntimeError: Unsupported database adapter: Trilogy>
```

Thankfully just adding `/trilogy/` to the case statement to point it to use the MySQL adapter seems to work fine!